### PR TITLE
Add travis configuration with jasmine js tests bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+dist: trusty
+language: php
+php:
+  - 7.0
+services:
+  - mysql
+sudo: required
+env:
+  global:
+    - MODULE_PATH=app/code/CtiDigital/GoogleAddressLookup
+    - DB=magento2
+    - DB_TEST=magento2_test
+    - DB_PASSWORD=password123
+    - DB_HOST=localhost
+    - MODULE_NAME=ctidigital/module-google-address-lookup
+  matrix:
+    - TEST_SUITE=js
+      MAGE_VERSION=2.1.7
+      MAGENTO_MODE=developer
+install:
+  - bash -c "if [ '$TEST_SUITE' = 'js' ]; then ./Travis/tasks/deps/install-node.sh; fi"
+  - bash -c "if [ '$TEST_SUITE' = 'js' ]; then ./Travis/tasks/deps/install-grunt-cli.sh; fi"
+before_script:
+  - echo "{\"http-basic\":{\"repo.magento.com\":{\"username\":\"${MAGENTO_USERNAME}\",\"password\":\"${MAGENTO_PASSWORD}\"}}}" > auth.json
+script:
+  - ./Travis/js-jasmine-runner.sh

--- a/Travis/config/Gruntfile.js.sample
+++ b/Travis/config/Gruntfile.js.sample
@@ -1,0 +1,104 @@
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// For performance use one level down: 'name/{,*/}*.js'
+// If you want to recursively match all subfolders, use: 'name/**/*.js'
+module.exports = function (grunt) {
+    'use strict';
+
+    var _ = require('underscore'),
+        path = require('path'),
+        themes = require('./dev/tools/grunt/configs/themes'),
+        configDir = './dev/tools/grunt/configs',
+        tasks = grunt.file.expand('./dev/tools/grunt/tasks/*');
+
+    tasks = _.map(tasks, function(task){ return task.replace('.js', '') });
+    tasks.push('time-grunt');
+    tasks.forEach(function (task) {
+        require(task)(grunt);
+    });
+
+    require('load-grunt-config')(grunt, {
+        configPath: path.join(__dirname, configDir),
+        init: true,
+        jitGrunt: {
+            staticMappings: {
+                usebanner: 'grunt-banner'
+            }
+        }
+    });
+
+    _.each({
+        /**
+         * Assembling tasks.
+         * ToDo: define default tasks.
+         */
+        default: function () {
+            grunt.log.subhead('I\'m default task and at the moment I\'m empty, sorry :/');
+        },
+
+        /**
+         * Production preparation task.
+         */
+        prod: function (component) {
+            var tasks = [
+                'less',
+                'autoprefixer',
+                'cssmin',
+                'usebanner'
+            ].map(function(task){
+                return task + ':' + component;
+            });
+
+            if (typeof component === 'undefined') {
+                grunt.log.subhead('Tip: Please make sure that u specify prod subtask. By default prod task do nothing');
+            } else {
+                grunt.task.run(tasks);
+            }
+        },
+
+        /**
+         * Refresh themes.
+         */
+        refresh: function () {
+            var tasks = [
+                'clean',
+                'exec:all'
+            ];
+            _.each(themes, function(theme, name) {
+                tasks.push('less:' + name);
+            });
+            grunt.task.run(tasks);
+        },
+
+        /**
+         * Documentation
+         */
+        documentation: [
+            'replace:documentation',
+            'less:documentation',
+            'styledocco:documentation',
+            'usebanner:documentationCss',
+            'usebanner:documentationLess',
+            'usebanner:documentationHtml',
+            'clean:var',
+            'clean:pub'
+        ],
+
+        'legacy-build': [
+            'mage-minify:legacy'
+        ],
+
+        spec: function (theme) {
+            var runner = require('./dev/tests/js/jasmine/spec_runner');
+
+            runner.init(grunt, { theme: theme });
+
+            grunt.task.run(runner.getTasks());
+        }
+    }, function (task, name) {
+        grunt.registerTask(name, task);
+    });
+};

--- a/Travis/config/package.json.sample
+++ b/Travis/config/package.json.sample
@@ -1,0 +1,44 @@
+{
+    "name": "Magento2",
+    "author": "Magento Commerce Inc.",
+    "description": "Magento2 node modules dependencies for local development",
+    "version": "2.0.0",
+    "license": "(OSL-3.0 OR AFL-3.0)",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/magento/magento2.git"
+    },
+    "homepage": "http://magento.com/",
+    "devDependencies": {
+        "glob": "^5.0.14",
+        "grunt": "^0.4.5",
+        "grunt-autoprefixer": "^2.0.0",
+        "grunt-banner": "^0.4.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-connect": "^0.9.0",
+        "grunt-contrib-cssmin": "^0.10.0",
+        "grunt-contrib-imagemin": "^0.9.2",
+        "grunt-contrib-jasmine": "^1.1.*",
+        "grunt-contrib-less": "^0.12.0",
+        "grunt-contrib-watch": "^0.6.1",
+        "grunt-eslint": "17.3.1",
+        "grunt-exec": "^0.4.6",
+        "grunt-jscs": "2.2.0",
+        "grunt-replace": "^0.9.2",
+        "grunt-styledocco": "^0.1.4",
+        "grunt-template-jasmine-requirejs": "^0.2.3",
+        "grunt-text-replace": "^0.4.0",
+        "imagemin-svgo": "^4.0.1",
+        "load-grunt-config": "^0.16.0",
+        "morgan": "^1.5.0",
+        "node-minify": "^1.0.1",
+        "path": "^0.11.14",
+        "serve-static": "^1.7.1",
+        "strip-json-comments": "^1.0.2",
+        "time-grunt": "^1.0.0",
+        "underscore": "^1.7.0"
+    },
+    "engines": {
+        "node": ">=0.10.0"
+    }
+}

--- a/Travis/config/settings.json.sample
+++ b/Travis/config/settings.json.sample
@@ -1,0 +1,69 @@
+{
+    "host": "http://localhost:<%= port %>",
+    "port": 8000,
+    "root": "dev/tests/js/jasmine",
+
+    /**
+     * Path to themes configuration module. Relative to Magento root.
+     * This node is replaced by formatted theme configuration by 'dev/tests/jasmine/spec_runner' module
+     */
+    "themes": "dev/tools/grunt/configs/themes",
+
+    "files": {
+        /**
+         * Path to RequireJS library. Relative to "server.base" config.
+         */
+        "requireJs": "requirejs/require.js",
+
+        /**
+         * Overridden "grunt-contrib-jasmine" SpecRunner template.
+         */
+        "template": "<%= root %>/spec_runner/template.html",
+
+        /**
+         * These files are included to the page in <head> right after "require.js" in declared sequence.
+         */
+        "requirejsConfigs": [
+            "pub/static/_requirejs/<%= area %>/<%= name %>/<%= locale %>/requirejs-config.js",
+            "<%= root %>/require.conf.js",
+            "<%= root %>/tests/lib/**/*.conf.js",
+            "<%= root %>/tests/app/code/**/base/**/*.conf.js",
+            "<%= root %>/tests/app/code/**/<%= area %>/**/*.conf.js",
+            "<%= root %>/tests/app/design/<%= area %>/<%= name %>/**/*.conf.js"
+        ],
+
+        /**
+         * Files that contain tests. These are loaded to the page via RequireJS after all RequireJS configuration files have been loaded to the page.
+         * The sequence is ignored.
+         */
+        "specs": [
+            "<%= root %>/tests/app/code/**/<%= area %>/**/*.test.js"
+        ]
+    },
+    "server": {
+        /**
+         * Directory to serve files from
+         */
+        "base": "pub/static/<%= area %>/<%= name %>/<%= locale %>",
+
+        /**
+         * Strings, mentioned here are interpreted as regular expressions. Use this option to override server's
+         *     default behaviour and serve matched urls "as is" from Magento root.
+         */
+        "serveAsIs": [
+            "^\/_SpecRunner.html",
+            "^\/dev\/tests",
+            "^\/.grunt",
+            "^\/pub\/static"
+        ],
+        "options": {
+            /**
+             * All options mentioned here are defaults for "connect" grunt task.
+             * "debug" option enables server logs
+             * "keepalive" makes "connect" task pause with set up spec server, which you can fetch by %host%:%port%/_SpecRunner.html address in browser
+             */
+            "debug": false,
+            "keepalive": false
+        }
+    }
+}

--- a/Travis/js-jasmine-runner.sh
+++ b/Travis/js-jasmine-runner.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+####################################################
+## Bootstrap and execute javascript jasmine tests ##
+####################################################
+
+./Travis/tasks/clone-magento.sh ${MAGE_VERSION}
+./Travis/tasks/create-database.sh
+./Travis/tasks/install-magento.sh
+./Travis/tasks/set-deploy-mode.sh ${MAGENTO_MODE}
+./Travis/tasks/install-module-files.sh
+./Travis/tasks/enable-modules.sh
+./Travis/tasks/static-content-deploy.sh
+./Travis/tasks/config-grunt.sh
+./Travis/tasks/run-jasmine-tests.sh

--- a/Travis/tasks/clone-magento.sh
+++ b/Travis/tasks/clone-magento.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#### Clones Magento 2 from GitHub repository with a given version
+
+echo Disabling xdebug for performance
+echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
+
+echo Cloning Magento..
+git clone https://github.com/magento/magento2 magento2
+cd magento2
+
+echo Setting Magento version $1
+git checkout tags/$1 -b $1
+
+composer install

--- a/Travis/tasks/config-grunt.sh
+++ b/Travis/tasks/config-grunt.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#### Configuring grunt along with installation of npm packages
+
+cd magento2
+
+cp ../Travis/config/Gruntfile.js.sample Gruntfile.js
+cp ../Travis/config/package.json.sample package.json
+cp ../Travis/config/settings.json.sample dev/tests/js/jasmine/spec_runner/settings.json
+
+npm install
+

--- a/Travis/tasks/create-database.sh
+++ b/Travis/tasks/create-database.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#### Creates database
+
+DB=${1:-"magento2"}
+
+echo Creating database...
+
+mysql -e "CREATE DATABASE IF NOT EXISTS $DB;"

--- a/Travis/tasks/deps/install-grunt-cli.sh
+++ b/Travis/tasks/deps/install-grunt-cli.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#### Install grunt cli
+
+npm install -g grunt-cli

--- a/Travis/tasks/deps/install-node.sh
+++ b/Travis/tasks/deps/install-node.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#### Install node with nvm
+
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+nvm install node

--- a/Travis/tasks/enable-modules.sh
+++ b/Travis/tasks/enable-modules.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#### Enables required modules
+MODULES=${1:-"--all"}
+
+cd magento2
+php bin/magento module:enable $MODULES

--- a/Travis/tasks/install-magento.sh
+++ b/Travis/tasks/install-magento.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#### Installs Magento2
+DB=${1:-"magento2"}
+
+cd magento2
+
+echo Installing magento...
+php bin/magento setup:install \
+    --admin-email="test@test.com" \
+    --admin-firstname="Joe" \
+    --admin-lastname="Doe" \
+    --admin-password="$DB_PASSWORD" \
+    --admin-user="admin" \
+    --backend-frontname="admin" \
+    --base-url="http://magento2.dev" \
+    --db-host="$DB_HOST" \
+    --db-name="$DB" \
+    --db-user="root" \
+    --session-save="files" \
+    --use-rewrites=1 \
+    --use-secure=0 \
+    -vvv

--- a/Travis/tasks/install-module-composer.sh
+++ b/Travis/tasks/install-module-composer.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#### Install composer module
+cd magento2
+
+echo Adding module github repository ${REPOSITORY}
+composer config repositories.google-address-lookup vcs ${REPOSITORY}
+
+if [ -z "${TRAVIS_TAG}" ]; then
+    echo Require module branch: ${TRAVIS_BRANCH} commit: ${TRAVIS_COMMIT}
+    composer require $1:dev-${TRAVIS_BRANCH}\#${TRAVIS_COMMIT}
+else
+    echo Require module release ${TRAVIS_TAG:1}
+    composer require $1:${TRAVIS_TAG:1}
+fi
+
+composer install

--- a/Travis/tasks/install-module-files.sh
+++ b/Travis/tasks/install-module-files.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#### Copy module files from current travis directory to a module root path
+
+echo Packing module files
+tar --exclude="./magento2" -czf module.tar.gz .
+
+cd magento2
+mkdir -p ${MODULE_PATH}
+
+echo Extracting module files to ${MODULE_PATH}
+tar -xf ../module.tar.gz -C ${MODULE_PATH}

--- a/Travis/tasks/run-jasmine-tests.sh
+++ b/Travis/tasks/run-jasmine-tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#### Copy module tests to dev/tests directory and run jasmine spec
+
+SPEC=${1:-"blank"}
+
+cd magento2
+
+mkdir -p dev/tests/js/jasmine/tests/${MODULE_PATH}
+cp -R ${MODULE_PATH}/Test/js/* dev/tests/js/jasmine/tests/${MODULE_PATH}
+
+grunt spec:$SPEC

--- a/Travis/tasks/set-deploy-mode.sh
+++ b/Travis/tasks/set-deploy-mode.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#### Set deploy mode
+
+MODE=${1:-"developer"}
+cd magento2
+
+echo Setting magento deploy mode => $MODE
+php bin/magento deploy:mode:set $MODE

--- a/Travis/tasks/static-content-deploy.sh
+++ b/Travis/tasks/static-content-deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#### Run static content deploy
+
+OPTIONS=${1:-""}
+
+cd magento2
+php bin/magento setup:static-content:deploy $OPTIONS


### PR DESCRIPTION
This PR introduces basic travis configuration with bash tasks scripts.
Main purpose for this PR is to execute module's js jasmine bdd tests with travis ci