### PR TITLE
issue with saving region on customer dashboard

### DIFF
--- a/view/frontend/templates/address/edit.phtml
+++ b/view/frontend/templates/address/edit.phtml
@@ -87,7 +87,6 @@
             <label class="label" for="region"><span><?php echo __('State/Province') ?></span></label>
             <div class="control">
                 <input type="text" id="region" name="region" data-autocomplete value="<?php echo $block->escapeHtml($block->getRegion()) ?>"  title="<?php echo __('State/Province') ?>" class="input-text <?php echo $this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('region') ?>"<?php echo(!$block->getConfig('general/region/display_all')) ? ' disabled="disabled"' : '';?>/>
-                <input type="hidden" id="region_id" name="region_id" value="1" />
             </div>
         </div>
         <div class="field zip required">


### PR DESCRIPTION
# Problem
The Region field is displayed, and populated with England. On saving it the address is then saved as having ‘Alabama’ in it.